### PR TITLE
Added possibility to configure ssl to "false"

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,7 +290,7 @@ FHEMPlatform(log, config) {
   this.filter  = config['filter'];
 
   var base_url;
-  if( config['ssl'] )
+  if( config['ssl'] && config['ssl'] == true )
     base_url = 'https://';
   else
     base_url = 'http://';


### PR DESCRIPTION
Currently the availability of the property "ssl" leads to the result despite the value being different from "true". Therefore an additional check is introduced with allows the configuration of "ssl" to anything else besides "true".