### PR TITLE
Improve debug browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ history:size=1024
 - max: the max value the reading has in fhem, only if different from maxValue
 - cmd: the set command to use: set \<device\> \<cmd\> \<value\>
 - cmdOn, cmdOff: for all bool characteristics
-- cmds: a ; separated list that indicates the mapping of homekit values to fhem values.
-        each list entry consists of a : separated pair of from and to values
-        each from value can be a literal value or a homekit defined term for this characteristic or a regex of the form /regex/
+- cmds: a ; separated list that indicates the mapping of homekit values to fhem values.  
+        each list entry consists of a : separated pair of from and to values  
+        each from value can be a literal value or a homekit defined term for this characteristic or a regex of the form /regex/  
         each to value has to be a literal value
 -cmdSuffix: is appended to the set command
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ adding a history characteristic will try to use fakegato-history to create Eve c
 history:size=1024
 ```
 
-
 ### Homekit -> FHEM parameters:
+
 - delay: true/\<number\> -> the value ist send afer one second/\<number\>ms of inactivity
 - factor: divide homekit value by this factor
 - maxValue: for all int and float characteristics -> the allowed range for this value in homekit
@@ -133,10 +133,10 @@ history:size=1024
 - cmd: the set command to use: set \<device\> \<cmd\> \<value\>
 - cmdOn, cmdOff: for all bool characteristics
 - cmds: a ; separated list that indicates the mapping of homekit values to fhem values.  
-        each list entry consists of a : separated pair of from and to values  
-        each from value can be a literal value or a homekit defined term for this characteristic or a regex of the form /regex/  
-        each to value has to be a literal value
--cmdSuffix: is appended to the set command
+    each list entry consists of a : separated pair of from and to values  
+    each from value can be a literal value or a homekit defined term for this characteristic or a regex of the form /regex/  
+    each to value has to be a literal value
+- cmdSuffix: is appended to the set command
 
 spaces in commands have to be replaced by +
 

--- a/index.js
+++ b/index.js
@@ -2476,7 +2476,7 @@ FHEMAccessory.prototype = {
     if( !this.delayed_timers )
       this.delayed_timers = {};
 
-    if( typeof delay !== 'numeric' )
+    if( typeof delay !== 'number' )
       delay = 1000;
     if( delay < 500 )
       delay = 500;

--- a/index.js
+++ b/index.js
@@ -3325,7 +3325,7 @@ function FHEMdebug_handleRequest(request, response){
 
   } else if( request.url == '/subscriptions' ) {
     response.write( '<a href="/">home</a><br><br>' );
-    response.end( 'subscriptions: ' + util.inspect(FHEM_subscriptions, {depth: 5}).replace(/\n/g, '<br>') );
+    response.end( '<pre>subscriptions: ' + util.inspect(FHEM_subscriptions, {depth: 5}) + '</pre>');
 
   } else
     response.end( '<a href="/cached">cached</a><br><a href="/subscriptions">subscriptions</a>' );


### PR DESCRIPTION
On my setup (homebridge on pi, browsing with edge) the `subscriptions` output was jumbled. Seems the pi wasn't able to replace huge strings. Anyhow, using the `<pre>` tag helped. 