### PR TITLE
Fix68 delayed cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ history:size=1024
 - max: the max value the reading has in fhem, only if different from maxValue
 - cmd: the set command to use: set \<device\> \<cmd\> \<value\>
 - cmdOn, cmdOff: for all bool characteristics
-- cmds: a ; separated list that indicates the mapping of homekit values to fhem values.
-        each list entry consists of a : separated pair of from and to values
-        each from value can be a literal value or a homekit defined term for this characteristic or a regex of the form /regex/
+- cmds: a ; separated list that indicates the mapping of homekit values to fhem values.  
+        each list entry consists of a : separated pair of from and to values  
+        each from value can be a literal value or a homekit defined term for this characteristic or a regex of the form /regex/  
         each to value has to be a literal value
 -cmdSuffix: is appended to the set command
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ adding a history characteristic will try to use fakegato-history to create Eve c
 history:size=1024
 ```
 
-
 ### Homekit -> FHEM parameters:
+
 - delay: true/\<number\> -> the value ist send afer one second/\<number\>ms of inactivity
 - factor: divide homekit value by this factor
 - maxValue: for all int and float characteristics -> the allowed range for this value in homekit
@@ -133,10 +133,10 @@ history:size=1024
 - cmd: the set command to use: set \<device\> \<cmd\> \<value\>
 - cmdOn, cmdOff: for all bool characteristics
 - cmds: a ; separated list that indicates the mapping of homekit values to fhem values.  
-        each list entry consists of a : separated pair of from and to values  
-        each from value can be a literal value or a homekit defined term for this characteristic or a regex of the form /regex/  
-        each to value has to be a literal value
--cmdSuffix: is appended to the set command
+    each list entry consists of a : separated pair of from and to values  
+    each from value can be a literal value or a homekit defined term for this characteristic or a regex of the form /regex/  
+    each to value has to be a literal value
+- cmdSuffix: is appended to the set command
 
 spaces in commands have to be replaced by +
 

--- a/index.js
+++ b/index.js
@@ -2481,17 +2481,17 @@ FHEMAccessory.prototype = {
     if( delay < 500 )
       delay = 500;
 
-    var timer = this.delayed_timers[mapping];
+    var timer = this.delayed_timers[mapping.informId];
     if( timer ) {
       //this.log(this.name + ' delayed: removing old command ' + mapping.characteristic_type);
       clearTimeout( timer );
     }
 
     this.log.info(this.name + ' delaying command ' + mapping.characteristic_type + ' with value ' + value);
-    this.delayed_timers[mapping] = setTimeout( function(){
-                                                 delete this.delayed_timers[mapping];
-                                                 this.command(mapping,value);
-                                               }.bind(this), delay );
+    this.delayed_timers[mapping.informId] = setTimeout( function(){
+        delete this.delayed_timers[mapping.informId];
+        this.command(mapping,value);
+      }.bind(this), delay );
   },
 
   command: function(mapping,value) {

--- a/index.js
+++ b/index.js
@@ -2476,7 +2476,7 @@ FHEMAccessory.prototype = {
     if( !this.delayed_timers )
       this.delayed_timers = {};
 
-    if( typeof delay !== 'numeric' )
+    if( typeof delay !== 'number' )
       delay = 1000;
     if( delay < 500 )
       delay = 500;


### PR DESCRIPTION
Seems indexing `delayed_timers` with `mapping` always hits the same element. Using the unique string `mapping.informId` helped. This is supposed to fix issue #68. 