### PR TITLE
add homematic ip thermostat support

### DIFF
--- a/lib/fhem.js
+++ b/lib/fhem.js
@@ -2401,6 +2401,10 @@ FHEMDevice(platform, s) {
       this.mappings[CustomUUIDs.Actuation] = { reading: 'ValvePosition',
                                                name: 'Actuation', format: 'UINT8', unit: 'PERCENTAGE',
                                                maxValue: 100, minValue: 0, minStep: 1  };
+    else if( s.Readings.LEVEL ) //HM-IP using HMCCU
+      this.mappings[CustomUUIDs.Actuation] = { reading: 'LEVEL',
+                                               name: 'Actuation', format: 'UINT8', unit: 'PERCENTAGE',
+                                               maxValue: 100, minValue: 0, minStep: 1  };
 
     if( match[3] ) {
       var values = match[3].split(',');


### PR DESCRIPTION
Small fix for HMCCU (homematic ip) thermostat valve position which has a different readings name `LEVEL` 