### PR TITLE
Fix: don't call HAP callback with undefined value

### DIFF
--- a/index.js
+++ b/index.js
@@ -2712,12 +2712,16 @@ FHEMAccessory.prototype = {
                     if( callback !== undefined ) {
                       if( value === undefined )
                         callback(1);
-                      else {
+					  else {
                         value = FHEM_reading2homekit(mapping, value);
-                        callback(undefined, value);
-                      }
-                    }
-
+                        if( value === undefined && mapping.cached !== undefined )
+                          callback(undefined, mapping.cached);
+                        else if( value === undefined )
+                          callback(1);
+                        else
+                          callback(undefined, value);
+                    	}                    
+					}
                     return value ;
 
                 }.bind(this) );


### PR DESCRIPTION
Under HAP-NodeJS v2 (bundled with Homebridge 2.0) combined with iOS/macOS 26.5, HomeKit strictly rejects characteristic values that don't match the expected type. The query() function in index.js passes the result of FHEM_reading2homekit() directly to the HAP callback, but that function can legitimately return undefined - for example when FHEM transiently returns a set command list like "set_off noArg" while a reading is in transition. Previously HAP only logged a warning; now it marks the accessory as "No Response".

This fix falls back to the last cached value if available, or signals an error otherwise, so HomeKit never receives an undefined value.

Related: issue #114

## Problem

After upgrading to Homebridge 2.0.x (HAP-NodeJS v2) and iOS 26.5, all FHEM devices showed "No Response" in Apple Home. The log contained recurring warnings:
[homebridge-fhem] This plugin generated a warning from the characteristic 'On':
characteristic value expected boolean and received undefined.

## Root Cause

In `index.js` around line 2716, the `query` function calls `FHEM_reading2homekit(mapping, value)` and passes the result directly to the HAP callback. This helper can return `undefined` by design — e.g. when FHEM returns a transitional value like `set_off noArg` that matches the `/^set_/` regex filter. Under HAP v1 this triggered only a warning; under HAP v2 + iOS 26.5 it causes the accessory to be marked unreachable.

## Fix

Check the return value before invoking the callback. If `FHEM_reading2homekit` returns undefined, fall back to the last cached value if available, otherwise signal an error. This preserves the existing behavior of filtering transitional FHEM states without breaking the HAP contract.

## Tested

Raspberry Pi 5, Homebridge 2.0.2, HAP v2.1.6, Node.js v24.15.0, homebridge-fhem 0.5.46 with this patch applied. All previously broken FHEM devices (switches, sensors, contact sensors) are now reachable in Apple Home again, no more "expected boolean and received undefined" warnings in the log.

Related: #114